### PR TITLE
Added unit tests for Graph Query Builder

### DIFF
--- a/src/Promitor.Tests.Unit/Builders/Queries/GraphQueryBuilderTests.cs
+++ b/src/Promitor.Tests.Unit/Builders/Queries/GraphQueryBuilderTests.cs
@@ -1,0 +1,227 @@
+﻿using System.Collections.Generic;
+using Promitor.Agents.ResourceDiscovery.Graph.Query;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Builders.Queries
+{
+    public class GraphQueryBuilderTests
+    {
+        private const string ResourceType = "resource type";
+
+        [Fact]
+        public void ForResourceType_SingleResourceType_ReturnsValidGraphQueryBuilder()
+        {
+            // Arrange
+            const string ExpectedQuery =
+                "Resources\r\n" +
+                "| where type =~ 'resource type'";
+
+            // Act
+            GraphQueryBuilder graphQueryBuilder = GraphQueryBuilder.ForResourceType(ResourceType);
+
+            // Assert
+            Assert.Equal(ExpectedQuery, graphQueryBuilder.Build());
+        }
+
+        [Fact]
+        public void ForResourceType_TwoResourceTypes_ReturnsValidGraphQueryBuilder()
+        {
+            // Arrange
+            const string ResourceType1 = "resource type 1";
+            const string ResourceType2 = "resource type 2";
+            const string ExpectedQuery =
+                "Resources\r\n" +
+                "| where type =~ 'resource type 1'\r\n" +
+                " or type =~ 'resource type 2'";
+
+            // Act
+            GraphQueryBuilder graphQueryBuilder = GraphQueryBuilder.ForResourceType(new[] { ResourceType1, ResourceType2 });
+
+            // Assert
+            Assert.Equal(ExpectedQuery, graphQueryBuilder.Build());
+        }
+
+        [Theory]
+        [InlineData(Operator.Contains, "contains")]
+        [InlineData(Operator.DoesNotContain, "!contains")]
+        [InlineData(Operator.DoesNotEquals, "!=")]
+        [InlineData(Operator.Equals, "==")]
+        public void Where_AppendCorrectQuery(Operator @operator, string queryOperatopr)
+        {
+            // Arrange
+            string ExpectedQuery =
+                "Resources\r\n" +
+                "| where type =~ 'resource type'\r\n" +
+                "| where field " + queryOperatopr + " 'value'";
+
+            GraphQueryBuilder graphQueryBuilder = GraphQueryBuilder.ForResourceType(ResourceType);
+
+            // Act
+            graphQueryBuilder.Where("field", @operator, "value");
+
+            // Assert
+            Assert.Equal(ExpectedQuery, graphQueryBuilder.Build());
+        }
+
+        [Fact]
+        public void WithSubscriptionsWithIds_AppendCorrectQuery()
+        {
+            // Arrange
+            const string ExpectedQuery =
+                "Resources\r\n" +
+                "| where type =~ 'resource type'\r\n" +
+                "| where subscriptionId =~ 'subscription Id 1' or subscriptionId =~ 'subscription Id 2' or subscriptionId =~ 'subscription Id 3'";
+
+            GraphQueryBuilder graphQueryBuilder = GraphQueryBuilder.ForResourceType(ResourceType);
+
+            List<string> subscriptionIds = new List<string>
+            {
+                "subscription Id 1",
+                "subscription Id 2",
+                "subscription Id 3"
+            };
+
+            // Act
+            graphQueryBuilder.WithSubscriptionsWithIds(subscriptionIds);
+
+            // Assert
+            Assert.Equal(ExpectedQuery, graphQueryBuilder.Build());
+        }
+
+        [Fact]
+        public void WithResourceGroupsWithName_AppendCorrectQuery()
+        {
+            // Arrange
+            const string ExpectedQuery =
+                "Resources\r\n" +
+                "| where type =~ 'resource type'\r\n" +
+                "| where resourceGroup =~ 'resourceGroup 1' or resourceGroup =~ 'resourceGroup 2' or resourceGroup =~ 'resourceGroup 3'";
+
+            GraphQueryBuilder graphQueryBuilder = GraphQueryBuilder.ForResourceType(ResourceType);
+
+            List<string> resourceGroups = new List<string>
+            {
+                "resourceGroup 1",
+                "resourceGroup 2",
+                "resourceGroup 3"
+            };
+
+            // Act
+            graphQueryBuilder.WithResourceGroupsWithName(resourceGroups);
+
+            // Assert
+            Assert.Equal(ExpectedQuery, graphQueryBuilder.Build());
+        }
+
+        [Fact]
+        public void WithinRegions_AppendCorrectQuery()
+        {
+            // Arrange
+            const string ExpectedQuery =
+                "Resources\r\n" +
+                "| where type =~ 'resource type'\r\n" +
+                "| where location =~ 'region 1' or location =~ 'region 2' or location =~ 'region 3'";
+
+            GraphQueryBuilder graphQueryBuilder = GraphQueryBuilder.ForResourceType(ResourceType);
+
+            List<string> regions = new List<string>
+            {
+                "region 1",
+                "region 2",
+                "region 3"
+            };
+
+            // Act
+            graphQueryBuilder.WithinRegions(regions);
+
+            // Assert
+            Assert.Equal(ExpectedQuery, graphQueryBuilder.Build());
+        }
+
+        [Fact]
+        public void WithinTags_AppendCorrectQuery()
+        {
+            // Arrange
+            const string ExpectedQuery =
+                "Resources\r\n" +
+                "| where type =~ 'resource type'\r\n" +
+                "| where tags['tag key 1'] == 'tag value 1' or tags['tag key 2'] == 'tag value 2' or tags['tag key 3'] == 'tag value 3'";
+
+            GraphQueryBuilder graphQueryBuilder = GraphQueryBuilder.ForResourceType(ResourceType);
+
+            Dictionary<string, string> tags = new Dictionary<string, string>
+            {
+                ["tag key 1"] = "tag value 1",
+                ["tag key 2"] = "tag value 2",
+                ["tag key 3"] = "tag value 3",
+            };
+
+            // Act
+            graphQueryBuilder.WithTags(tags);
+
+            // Assert
+            Assert.Equal(ExpectedQuery, graphQueryBuilder.Build());
+        }
+
+        [Fact]
+        public void Project_SingleField_ReturnsValidGraphQueryBuilder()
+        {
+            // Arrange
+            const string ExpectedQuery =
+                "Resources\r\n" +
+                "| where type =~ 'resource type'\r\n" +
+                "| project field";
+
+            GraphQueryBuilder graphQueryBuilder = GraphQueryBuilder.ForResourceType(ResourceType);
+
+            // Act
+            graphQueryBuilder.Project("field");
+
+            // Assert
+            Assert.Equal(ExpectedQuery, graphQueryBuilder.Build());
+        }
+
+        [Fact]
+        public void Project_TwoFields_ReturnsValidGraphQueryBuilder()
+        {
+            // Arrange
+            const string Field1 = "field 1";
+            const string Field2 = "field 2";
+
+            const string ExpectedQuery =
+                "Resources\r\n" +
+                "| where type =~ 'resource type'\r\n" +
+                "| project field 1, field 2";
+
+            GraphQueryBuilder graphQueryBuilder = GraphQueryBuilder.ForResourceType(ResourceType);
+
+            // Act
+            graphQueryBuilder.Project(new[] { Field1, Field2 });
+
+            // Assert
+            Assert.Equal(ExpectedQuery, graphQueryBuilder.Build());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(10)]
+        [InlineData(17)]
+        [InlineData(57)]
+        public void Limit2_AppendCorrectQuery(int limit)
+        {
+            // Arrange
+            string ExpectedQuery =
+                "Resources\r\n" +
+                "| where type =~ 'resource type'\r\n" +
+                "| limit " + limit;
+
+            GraphQueryBuilder graphQueryBuilder = GraphQueryBuilder.ForResourceType(ResourceType);
+
+            // Act
+            graphQueryBuilder.LimitTo(limit);
+
+            // Assert
+            Assert.Equal(ExpectedQuery, graphQueryBuilder.Build());
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper
- [ ] Add entry to changelog

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Add unit tests for Graph Query Builder

<!-- markdownlint-enable -->